### PR TITLE
Remove black from diff-shades

### DIFF
--- a/src/diff_shades/config.py
+++ b/src/diff_shades/config.py
@@ -36,7 +36,6 @@ PROJECTS: Final = [
     Project("aioexabgp", "https://github.com/cooperlees/aioexabgp.git"),
     Project("attrs", "https://github.com/python-attrs/attrs.git"),
     Project("bandersnatch", "https://github.com/pypa/bandersnatch.git"),
-    Project("black", "https://github.com/psf/black.git"),
     Project("blackbench", "https://github.com/ichard26/blackbench.git"),
     Project("channel", "https://github.com/django/channels.git"),
     Project("diff-shades", "https://github.com/ichard26/diff-shades.git"),


### PR DESCRIPTION
Quick fix for https://github.com/psf/black/pull/4164 + Black is a bit of a special case and we're very aware of changes to formatting on Black.