### PR TITLE
Update Python version requirements and arguments

### DIFF
--- a/src/diff_shades/config.py
+++ b/src/diff_shades/config.py
@@ -39,8 +39,7 @@ PROJECTS: Final = [
     Project(
         "blackbench",
         "https://github.com/ichard26/blackbench.git",
-        # Uses Python 3.12+ type alias syntax
-        custom_arguments=["--extend-exclude", "/src/bandersnatch/tests/test_mirror.py"],
+        python_requires=">=3.12",
     ),
     Project("channel", "https://github.com/django/channels.git"),
     Project("diff-shades", "https://github.com/ichard26/diff-shades.git"),
@@ -48,15 +47,10 @@ PROJECTS: Final = [
         "django",
         "https://github.com/django/django.git",
         custom_arguments=[
-            "--skip-string-normalization",
             "--extend-exclude",
-            (
-                "/((docs|scripts)/|django/forms/models.py"
-                "|tests/gis_tests/test_spatialrefsys.py"
-                "|tests/test_runner_apps/tagged/tests_syntax_error.py)"
-            ),
+            "/tests/test_runner_apps/tagged/tests_syntax_error.py",
         ],
-        python_requires=">=3.8",
+        python_requires=">=3.11",
     ),
     Project("flake8-bugbear", "https://github.com/PyCQA/flake8-bugbear.git"),
     Project("hypothesis", "https://github.com/HypothesisWorks/hypothesis.git"),
@@ -70,8 +64,7 @@ PROJECTS: Final = [
     Project(
         "scikit-lego",
         "https://github.com/koaning/scikit-lego.git",
-        # Uses Python 3.12+ f-string syntax, not yet supported by Black
-        custom_arguments=["--extend-exclude", "/docs/_scripts/feature-selection.py"],
+        python_requires=">=3.12",
     ),
     Project("sqlalchemy", "https://github.com/sqlalchemy/sqlalchemy.git"),
     Project("tox", "https://github.com/tox-dev/tox.git"),

--- a/src/diff_shades/config.py
+++ b/src/diff_shades/config.py
@@ -36,7 +36,12 @@ PROJECTS: Final = [
     Project("aioexabgp", "https://github.com/cooperlees/aioexabgp.git"),
     Project("attrs", "https://github.com/python-attrs/attrs.git"),
     Project("bandersnatch", "https://github.com/pypa/bandersnatch.git"),
-    Project("blackbench", "https://github.com/ichard26/blackbench.git"),
+    Project(
+        "blackbench",
+        "https://github.com/ichard26/blackbench.git",   
+        # Uses Python 3.12+ type alias syntax
+        custom_arguments=["--extend-exclude", "/src/bandersnatch/tests/test_mirror.py"],
+    ),
     Project("channel", "https://github.com/django/channels.git"),
     Project("diff-shades", "https://github.com/ichard26/diff-shades.git"),
     Project(

--- a/src/diff_shades/config.py
+++ b/src/diff_shades/config.py
@@ -38,7 +38,7 @@ PROJECTS: Final = [
     Project("bandersnatch", "https://github.com/pypa/bandersnatch.git"),
     Project(
         "blackbench",
-        "https://github.com/ichard26/blackbench.git",   
+        "https://github.com/ichard26/blackbench.git",
         # Uses Python 3.12+ type alias syntax
         custom_arguments=["--extend-exclude", "/src/bandersnatch/tests/test_mirror.py"],
     ),

--- a/src/diff_shades/config.py
+++ b/src/diff_shades/config.py
@@ -35,12 +35,12 @@ class Project:
 PROJECTS: Final = [
     Project("aioexabgp", "https://github.com/cooperlees/aioexabgp.git"),
     Project("attrs", "https://github.com/python-attrs/attrs.git"),
-    Project("bandersnatch", "https://github.com/pypa/bandersnatch.git"),
     Project(
-        "blackbench",
-        "https://github.com/ichard26/blackbench.git",
+        "bandersnatch",
+        "https://github.com/pypa/bandersnatch.git",
         python_requires=">=3.12",
     ),
+    Project("blackbench", "https://github.com/ichard26/blackbench.git"),
     Project("channel", "https://github.com/django/channels.git"),
     Project("diff-shades", "https://github.com/ichard26/diff-shades.git"),
     Project(


### PR DESCRIPTION
[Bandersnatch now uses 3.12+ type aliases.](https://github.com/pypa/bandersnatch/commit/ee73b35033cfeaaf1e951827607dde1e56d2573e#diff-7092307fd077d2bc1a345b731bc1d930e384d416fc0c0699bed77ae4ffd8ae54R1222)
We support f-strings now, so I changed scikit-lego to run on 3.12.
Not sure what the issues with Django were, but those files are parsable by Black now on my end. I did find a file that uses 3.11+ `except*` syntax that failed on 3.10 for me; not sure why diff-shades *didn't* fail but I bumped the required version to 3.13.

diff-shades is currently run on 3.11 on Black CI. It won't crash, but it will skip Bandersnatch and scikit-lego until https://github.com/psf/black/pull/4867 is merged.